### PR TITLE
Fix a bug with SolverError

### DIFF
--- a/src/ipopt-common.hxx
+++ b/src/ipopt-common.hxx
@@ -50,9 +50,9 @@ namespace roboptim
   ~IpoptSolverCommon () throw ()
   {}
   
+  // /!\ this->result_ is filled by tnlp.hxx, do not overwrite!
 #define SWITCH_ERROR(NAME, ERROR)		\
   case NAME:					\
-  this->result_ = SolverError (ERROR);		\
   break
 
 #define SWITCH_FATAL(NAME)			\


### PR DESCRIPTION
SolverError was overwritten in IpoptSolverCommon, making the latest changes useless.
