### PR TITLE
Improve plugin validation

### DIFF
--- a/src/ipopt-sparse.cc
+++ b/src/ipopt-sparse.cc
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <typeinfo>
 
 #include <boost/foreach.hpp>
 #include <boost/variant/apply_visitor.hpp>
@@ -33,8 +34,8 @@
 
 namespace roboptim
 {
-  typedef Solver<DifferentiableFunction,
-		 boost::mpl::vector<LinearFunction,
+  typedef Solver<DifferentiableSparseFunction,
+                 boost::mpl::vector<LinearSparseFunction,
 				    DifferentiableSparseFunction> >
   ipopt_solver_t;
 
@@ -61,12 +62,18 @@ extern "C"
   typedef IpoptSolverSparse::solver_t solver_t;
 
   ROBOPTIM_DLLEXPORT unsigned getSizeOfProblem ();
+  ROBOPTIM_DLLEXPORT const char* getTypeIdOfConstraintsList ();
   ROBOPTIM_DLLEXPORT solver_t* create (const IpoptSolverSparse::problem_t& pb);
   ROBOPTIM_DLLEXPORT void destroy (solver_t* p);
 
   ROBOPTIM_DLLEXPORT unsigned getSizeOfProblem ()
   {
     return sizeof (IpoptSolverSparse::problem_t);
+  }
+
+  ROBOPTIM_DLLEXPORT const char* getTypeIdOfConstraintsList ()
+  {
+    return typeid (IpoptSolverSparse::problem_t::constraintsList_t).name ();
   }
 
   ROBOPTIM_DLLEXPORT solver_t* create (const IpoptSolverSparse::problem_t& pb)

--- a/src/ipopt-td.cc
+++ b/src/ipopt-td.cc
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <typeinfo>
 
 #include <boost/foreach.hpp>
 #include <boost/variant/apply_visitor.hpp>
@@ -62,12 +63,18 @@ extern "C"
   typedef IpoptSolverTd::solver_t solver_t;
 
   ROBOPTIM_DLLEXPORT unsigned getSizeOfProblem ();
+  ROBOPTIM_DLLEXPORT const char* getTypeIdOfConstraintsList ();
   ROBOPTIM_DLLEXPORT solver_t* create (const IpoptSolverTd::problem_t& pb);
   ROBOPTIM_DLLEXPORT void destroy (solver_t* p);
 
   ROBOPTIM_DLLEXPORT unsigned getSizeOfProblem ()
   {
     return sizeof (IpoptSolverTd::problem_t);
+  }
+
+  ROBOPTIM_DLLEXPORT const char* getTypeIdOfConstraintsList ()
+  {
+    return typeid (IpoptSolverTd::problem_t::constraintsList_t).name ();
   }
 
   ROBOPTIM_DLLEXPORT solver_t* create (const IpoptSolverTd::problem_t& pb)

--- a/src/ipopt.cc
+++ b/src/ipopt.cc
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <typeinfo>
 
 #include <boost/foreach.hpp>
 #include <boost/variant/apply_visitor.hpp>
@@ -60,12 +61,18 @@ extern "C"
   typedef IpoptSolver::solver_t solver_t;
 
   ROBOPTIM_DLLEXPORT unsigned getSizeOfProblem ();
+  ROBOPTIM_DLLEXPORT const char* getTypeIdOfConstraintsList ();
   ROBOPTIM_DLLEXPORT solver_t* create (const IpoptSolver::problem_t& pb);
   ROBOPTIM_DLLEXPORT void destroy (solver_t* p);
 
   ROBOPTIM_DLLEXPORT unsigned getSizeOfProblem ()
   {
     return sizeof (IpoptSolver::problem_t);
+  }
+
+  ROBOPTIM_DLLEXPORT const char* getTypeIdOfConstraintsList ()
+  {
+    return typeid (IpoptSolver::problem_t::constraintsList_t).name ();
   }
 
   ROBOPTIM_DLLEXPORT solver_t* create (const IpoptSolver::problem_t& pb)


### PR DESCRIPTION
Constraint types provided as `boost::mpl::vector` are now checked by roboptim-core.
