### PR TITLE
More fixes using Eigen::Ref, plus type renaming.

### DIFF
--- a/src/tnlp.cc
+++ b/src/tnlp.cc
@@ -67,6 +67,27 @@ namespace roboptim
 
     template <>
     bool
+    Tnlp<IpoptSolverSparse>::eval_grad_f(Index n, const Number* x, bool, Number* grad_f)
+    {
+      assert (solver_.problem ().function ().inputSize () - n == 0);
+
+      if (!costGradient_)
+	costGradient_ = typename function_t::gradient_t
+	  (solver_.problem ().function ().inputSize ());
+
+      Eigen::Map<const typename function_t::argument_t> x_ (x, n);
+      solver_.problem ().function ().gradient (*costGradient_, x_, 0);
+
+      IpoptCheckGradient
+        (solver_.problem ().function (), 0, x_, -1, solver_);
+
+      Eigen::Map<typename function_t::vector_t> grad_f_ (grad_f, n);
+      grad_f_ =  *costGradient_;
+      return true;
+    }
+
+    template <>
+    bool
     Tnlp<IpoptSolverSparse>::eval_jac_g(Index n, const Number* x, bool,
 					Index ROBOPTIM_DEBUG_ONLY(m),
 					Index nele_jac,

--- a/src/tnlp.cc
+++ b/src/tnlp.cc
@@ -81,8 +81,8 @@ namespace roboptim
 
       if (!jacobian_)
 	{
-	  jacobian_ = function_t::matrix_t
-	    (static_cast<function_t::matrix_t::Index> (constraintsOutputSize ()),
+	  jacobian_ = function_t::jacobian_t
+	    (static_cast<function_t::jacobian_t::Index> (constraintsOutputSize ()),
 	     solver_.problem ().function ().inputSize ());
 	  jacobian_->reserve (nele_jac);
 	}

--- a/src/tnlp.hh
+++ b/src/tnlp.hh
@@ -170,14 +170,11 @@ namespace roboptim
       /// \brief Current state of the solver (used by the callback function).
       solverState_t solverState_;
 
-      /// \brief Cost function buffer.
-      boost::optional<typename function_t::result_t> cost_;
-
       /// \brief Cost gradient buffer.
       boost::optional<typename function_t::gradient_t> costGradient_;
 
       /// \brief Constraints jacobian buffer.
-      boost::optional<typename function_t::matrix_t> jacobian_;
+      boost::optional<typename function_t::jacobian_t> jacobian_;
     };
   } // end of namespace detail.
 } // end of namespace roboptim.

--- a/src/tnlp.hxx
+++ b/src/tnlp.hxx
@@ -316,24 +316,23 @@ namespace roboptim
       return true;
     }
 
+    template <>
+    bool
+    Tnlp<IpoptSolverSparse>::eval_grad_f(Index n, const Number* x, bool, Number* grad_f);
+
     template <typename T>
     bool
     Tnlp<T>::eval_grad_f (Index n, const Number* x, bool, Number* grad_f)
     {
       assert (solver_.problem ().function ().inputSize () - n == 0);
 
-      if (!costGradient_)
-	costGradient_ = typename function_t::gradient_t
-	  (solver_.problem ().function ().inputSize ());
-
       Eigen::Map<const typename function_t::argument_t> x_ (x, n);
-      solver_.problem ().function ().gradient (*costGradient_, x_, 0);
+      Eigen::Map<typename function_t::gradient_t> grad_f_ (grad_f, n);
+      solver_.problem ().function ().gradient (grad_f_, x_, 0);
 
       IpoptCheckGradient
         (solver_.problem ().function (), 0, x_, -1, solver_);
 
-      Eigen::Map<typename function_t::vector_t> grad_f_ (grad_f, n);
-      grad_f_ =  *costGradient_;
       return true;
     }
 

--- a/src/tnlp.hxx
+++ b/src/tnlp.hxx
@@ -127,7 +127,6 @@ namespace roboptim
     Tnlp<T>::Tnlp (const typename solver_t::problem_t& pb, solver_t& solver)
       : solver_ (solver),
         solverState_ (pb),
-	cost_ (),
 	costGradient_ (),
 	jacobian_ ()
     {
@@ -310,12 +309,10 @@ namespace roboptim
     {
       assert (solver_.problem ().function ().inputSize () - n == 0);
 
-      if (!cost_)
-        cost_ = typename function_t::vector_t (1);
+      Eigen::Map<typename function_t::result_t> cost_ (&obj_value, 1);
       Eigen::Map<const typename function_t::argument_t> x_ (x, n);
-      solver_.problem ().function () (*cost_, x_);
+      solver_.problem ().function () (cost_, x_);
 
-      obj_value = (*cost_)[0];
       return true;
     }
 


### PR DESCRIPTION
This is probably the furthest we can go using Eigen::Refs to avoid implicit copies. It is not possible to completely disable the use of local jacobian_ and costGradient_ because when manipulating Sparse data, there is no point in using Refs. The only thing that could be done right now is specializing the case for IpoptSolverSparse, letting the Dense one use the cleaner version.